### PR TITLE
Fixes Password Reset Link

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -130,10 +130,15 @@ function wc_edit_address_i18n( $id, $flip = false ) {
  * @access public
  * @return string
  */
-function wc_lostpassword_url() {
-    return wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) );
+function wc_lostpassword_url( $default_login_page ) {
+	$login_page = wc_get_page_permalink( 'myaccount' );
+	if ( false !== $login_page ) {
+    	return wc_get_endpoint_url( 'lost-password', '', $login_page );
+	} else {
+		return $default_login_page;
+	}
 }
-add_filter( 'lostpassword_url',  'wc_lostpassword_url', 10, 0 );
+add_filter( 'lostpassword_url',  'wc_lostpassword_url', 10, 1 );
 
 
 /**


### PR DESCRIPTION
When the woocommerce pages have not been setup yet the password reset link on wp-login.php is ?lostpassword instead of ?action=lostpassword
